### PR TITLE
Set a consistent timezone for testing

### DIFF
--- a/src/ServiceContainer/BehatExtension.php
+++ b/src/ServiceContainer/BehatExtension.php
@@ -41,6 +41,9 @@ class BehatExtension implements ExtensionInterface
 
     public function __construct()
     {
+        // force the default timezone to UTC
+        ini_set('date.timezone', 'UTC');
+
         // Supported database drivers
         $this->registerDatabaseDriverFactory(new MySQLFactory());
         $this->registerDatabaseDriverFactory(new SQLiteFactory());


### PR DESCRIPTION
Setting the timezone to be UTC, to aid time based testing allow for consistency when running on different environments/machines